### PR TITLE
Fixed formatting & removed some links/phrases. V2

### DIFF
--- a/content/blog/is-it-legal-for-a-company-to-ask-an-employee-to-sign-an-nda-after-the-employee-has-started-working/index.md
+++ b/content/blog/is-it-legal-for-a-company-to-ask-an-employee-to-sign-an-nda-after-the-employee-has-started-working/index.md
@@ -12,38 +12,46 @@ Small Business Law Library
 Today’s job market is tough, so whe..."
 ---
 
-[https://pixabay.com/en/building-neon-sign-communication-804526/](https://pixabay.com/en/building-neon-sign-communication-804526/)
-**Links from this article:**[Non-Disclosure Agreement](https://clausehound.com/legal-contract/15656#!/document=)[Analysis of Holland v Hostopia.com Inc](http://www.canadianemploymentpensionlaw.com/termination/seeking-to-introduce-new-terms-of-employment-court-of-appeal-reminds-us-that-fresh-consideration-is/)[Small Business Law Library](https://clausehound.com/small-business-law-library/)
+
+**Links from this article:** [Non-Disclosure Agreement; ](https://clausehound.com/legal-contract/15656#!/document=)[Analysis of Holland v Hostopia.com Inc; ](https://canliiconnects.org/en/commentaries/39223/)[Small Business Law Library.](https://www.clausehound.com/documents/)
 
 Today’s job market is tough, so when an employment opportunity presents itself, many jump at the chance and take the job. You might notice that the offer letter you accepted in lieu of a full-fledged employment agreement (which, along with other documents, you were promised would be delivered soon) may include terms which are different from those included in the contract itself. Usually that’s not an issue for employees - you have a job now! You can clarify what the contract terms are, and sign it so you can start getting paid!
 
  
 
-But suppose you have started work and the employer now requires you to sign an additional contract, like a confidentiality agreement or non-disclosure agreement (NDA). You don’t want to lose your job, so you will likely sign. Will you be bound by this NDA? The answer is both yes and no - it depends on whether there has been fresh consideration for the new contract.
-** **
+But suppose you have started work and the employer now requires you to sign an *additional contract*, like a confidentiality agreement or non-disclosure agreement (NDA). You don’t want to lose your job, so you will likely sign. Will you be bound by this NDA? The answer is both yes and no - it depends on whether there has been fresh consideration for the new contract.
+
 **Offer, acceptance, and consideration**
 
-A contract is legally binding if it is composed of three parts: an offer of a contract from one party to the other; an acceptance by the other party of those terms; and consideration, something of value that each party has and will exchange with one another (e.g., money, services, promises).
+A contract is legally binding if it is composed of three (3) parts: an offer of a contract from one party to the other; an acceptance by the other party of those terms; and consideration, something of value that each party has and will exchange with one another (e.g., money, services, promises).
 
  
 
-**Fresh Consideration  **
+**Fresh Consideration**
 
 When an employee is presented with a new set of terms or a new agreement, it is not considered to be enforceable unless consideration is present. But the courts have held that that consideration cannot be the same as previously offered or given—it has to be more, and this is called “fresh consideration.”
 
  
 
-The Ontario Court of Appeal recently considered the question, in [Holland v. Hostopia Inc. (2015) (ONCA)](http://www.canadianemploymentpensionlaw.com/termination/seeking-to-introduce-new-terms-of-employment-court-of-appeal-reminds-us-that-fresh-consideration-is/). The court stated that simply keeping the job you are entitled to keep is not fresh consideration that will support the signing of another contract (like an NDA). On the other hand, not being dismissed when you could legally be dismissed will be fresh consideration. Whether the employer can require you to sign the new contract as a condition of keeping your employment may depend on whether you could have been legally ‘let go’ even if you did not sign the new contract.
+The Ontario Court of Appeal recently considered the question, in [Holland v. Hostopia Inc. (2015) (ONCA)](https://canliiconnects.org/en/commentaries/39223/). The court stated that simply keeping the job you are entitled to keep is not fresh consideration that will support the signing of another contract (like an NDA). On the other hand, not being dismissed when you could legally be dismissed will be fresh consideration. Whether the employer can require you to sign the new contract as a condition of keeping your employment may depend on whether you could have been legally ‘let go’ even if you did not sign the new contract.
 
  
 
-What will count as fresh consideration? Continuing in a job when the employer was entitled to let you go is fresh consideration. Offering a bonus can be fresh consideration (even if the bonus is a modest amount). Some other forms of fresh consideration can include “an increase of vacation pay, notice requirements, life insurance, severance pay, or health and dental benefits.” Note that any one of these things by itself could be sufficient to be considered to be fresh consideration.** **
-[Source](https://pixabay.com/en/sign-stop-warning-stop-sign-symbol-1732791/)
-**No Consideration **
+**What will count as fresh consideration?** 
 
-Employers are sometimes tempted to avoid the need for fresh consideration by including the following sort of clause: “The party affirms that the terms stated herein are the only consideration for signing this Agreement and that no other representations, promises, or agreements of any kind have been made by any person or entity to cause them to sign this Agreement.
+Continuing in a job when the employer was entitled to let you go is fresh consideration. Offering a bonus can be fresh consideration (even if the bonus is a modest amount). Some other forms of fresh consideration can include “an increase of vacation pay, notice requirements, life insurance, severance pay, or health and dental benefits.” 
 
-The party affirms that this consideration is sufficient. The party has accepted the terms of this Agreement because they believe them to be fair and reasonable for no other reason.”
+Note that any one of these things by itself could be sufficient to be considered as fresh consideration.
+
+**No Consideration**
+
+Employers are sometimes tempted to avoid the need for fresh consideration by including the following sort of clause: 
+
+“*The party affirms that the terms stated herein are the only consideration for signing this Agreement and that no other representations, promises, or agreements of any kind have been made by any person or entity to cause them to sign this Agreement.*
+
+*The party affirms that this consideration is sufficient.* 
+
+*The party has accepted the terms of this Agreement because they believe them to be fair and reasonable for no other reason.*”
 
  
 
@@ -55,8 +63,8 @@ So, is it legal to ask an employee to sign an NDA after the employee has started
 
  
 
-To see standard versions of the various agreements and contracts discussed in this article, visit our [Small Business Law Library](https://clausehound.com/legal-contract/14918/#!/document=)!
+To see standard versions of the various agreements and contracts discussed in this article, visit our [Small Business Law Library](https://www.clausehound.com/documents/)!
 
  
 
-This blog was co-written by Alina Butt.
+*This blog was co-written by Alina Butt.*

--- a/content/blog/is-it-legal-for-a-company-to-ask-an-employee-to-sign-an-nda-after-the-employee-has-started-working/index.md
+++ b/content/blog/is-it-legal-for-a-company-to-ask-an-employee-to-sign-an-nda-after-the-employee-has-started-working/index.md
@@ -13,7 +13,7 @@ Today’s job market is tough, so whe..."
 ---
 
 
-**Links from this article:** [Non-Disclosure Agreement; ](https://clausehound.com/legal-contract/15656#!/document=)[Analysis of Holland v Hostopia.com Inc; ](https://canliiconnects.org/en/commentaries/39223/)[Small Business Law Library.](https://www.clausehound.com/documents/)
+
 
 Today’s job market is tough, so when an employment opportunity presents itself, many jump at the chance and take the job. You might notice that the offer letter you accepted in lieu of a full-fledged employment agreement (which, along with other documents, you were promised would be delivered soon) may include terms which are different from those included in the contract itself. Usually that’s not an issue for employees - you have a job now! You can clarify what the contract terms are, and sign it so you can start getting paid!
 
@@ -21,13 +21,13 @@ Today’s job market is tough, so when an employment opportunity presents itself
 
 But suppose you have started work and the employer now requires you to sign an *additional contract*, like a confidentiality agreement or non-disclosure agreement (NDA). You don’t want to lose your job, so you will likely sign. Will you be bound by this NDA? The answer is both yes and no - it depends on whether there has been fresh consideration for the new contract.
 
-**Offer, acceptance, and consideration**
+### Offer, acceptance, and consideration
 
 A contract is legally binding if it is composed of three (3) parts: an offer of a contract from one party to the other; an acceptance by the other party of those terms; and consideration, something of value that each party has and will exchange with one another (e.g., money, services, promises).
 
  
 
-**Fresh Consideration**
+### Fresh Consideration
 
 When an employee is presented with a new set of terms or a new agreement, it is not considered to be enforceable unless consideration is present. But the courts have held that that consideration cannot be the same as previously offered or given—it has to be more, and this is called “fresh consideration.”
 
@@ -37,13 +37,13 @@ The Ontario Court of Appeal recently considered the question, in [Holland v. Hos
 
  
 
-**What will count as fresh consideration?** 
+### What will count as fresh consideration?
 
 Continuing in a job when the employer was entitled to let you go is fresh consideration. Offering a bonus can be fresh consideration (even if the bonus is a modest amount). Some other forms of fresh consideration can include “an increase of vacation pay, notice requirements, life insurance, severance pay, or health and dental benefits.” 
 
 Note that any one of these things by itself could be sufficient to be considered as fresh consideration.
 
-**No Consideration**
+### No Consideration
 
 Employers are sometimes tempted to avoid the need for fresh consideration by including the following sort of clause: 
 
@@ -67,4 +67,4 @@ To see standard versions of the various agreements and contracts discussed in th
 
  
 
-*This blog was co-written by Alina Butt.*
+

--- a/content/blog/is-it-legal-for-a-company-to-ask-an-employee-to-sign-an-nda-after-the-employee-has-started-working/index.md
+++ b/content/blog/is-it-legal-for-a-company-to-ask-an-employee-to-sign-an-nda-after-the-employee-has-started-working/index.md
@@ -3,21 +3,10 @@ title: "Is it legal for a company to ask an employee to sign an NDA after the em
 author: frahman@cobaltcounsel.com
 tags: ["NDA","Employment Agreement","frahman"]
 date: 2017-04-21 11:00:42
-description: "Links from this article:
-Non-Disclosure Agreement
-Analysis of Holland v Hostopia.com Inc
-Small Business Law Library
-
-
-Today’s job market is tough, so whe..."
+description: "This article discusses the circumstances in which an employee will be bound by an NDA after they have started working."
 ---
 
-
-
-
 Today’s job market is tough, so when an employment opportunity presents itself, many jump at the chance and take the job. You might notice that the offer letter you accepted in lieu of a full-fledged employment agreement (which, along with other documents, you were promised would be delivered soon) may include terms which are different from those included in the contract itself. Usually that’s not an issue for employees - you have a job now! You can clarify what the contract terms are, and sign it so you can start getting paid!
-
- 
 
 But suppose you have started work and the employer now requires you to sign an *additional contract*, like a confidentiality agreement or non-disclosure agreement (NDA). You don’t want to lose your job, so you will likely sign. Will you be bound by this NDA? The answer is both yes and no - it depends on whether there has been fresh consideration for the new contract.
 
@@ -25,17 +14,11 @@ But suppose you have started work and the employer now requires you to sign an *
 
 A contract is legally binding if it is composed of three (3) parts: an offer of a contract from one party to the other; an acceptance by the other party of those terms; and consideration, something of value that each party has and will exchange with one another (e.g., money, services, promises).
 
- 
-
 ### Fresh Consideration
 
 When an employee is presented with a new set of terms or a new agreement, it is not considered to be enforceable unless consideration is present. But the courts have held that that consideration cannot be the same as previously offered or given—it has to be more, and this is called “fresh consideration.”
 
- 
-
 The Ontario Court of Appeal recently considered the question, in [Holland v. Hostopia Inc. (2015) (ONCA)](https://canliiconnects.org/en/commentaries/39223/). The court stated that simply keeping the job you are entitled to keep is not fresh consideration that will support the signing of another contract (like an NDA). On the other hand, not being dismissed when you could legally be dismissed will be fresh consideration. Whether the employer can require you to sign the new contract as a condition of keeping your employment may depend on whether you could have been legally ‘let go’ even if you did not sign the new contract.
-
- 
 
 ### What will count as fresh consideration?
 
@@ -53,18 +36,8 @@ Employers are sometimes tempted to avoid the need for fresh consideration by inc
 
 *The party has accepted the terms of this Agreement because they believe them to be fair and reasonable for no other reason.*”
 
- 
-
 If you are an employer who wants to have an existing employee sign another contract, be wary of relying on such clauses… the courts will look at whether you actually gave something new to the employee as fresh consideration in exchange for signing the contract.
-
- 
 
 So, is it legal to ask an employee to sign an NDA after the employee has started working? Yes, and no! When drafting the employment agreement, it is wise to include a clause requiring the employee to execute such further documents and agreements as the employer deems reasonably necessary - and then, when they sign those documents, remember to give some fresh consideration with the agreement.
 
- 
-
 To see standard versions of the various agreements and contracts discussed in this article, visit our [Small Business Law Library](https://www.clausehound.com/documents/)!
-
- 
-
-


### PR DESCRIPTION
Hi Bronwynne,

We have removed:
"Co-written" by sentence and first links in the articles.
I'll do this on succeeding articles.


Also, the bolded headers are now set into heading format (###).

On previous articles, the headers were set to a smaller bold format (** **). Do you suggest re-work? :)