### PR TITLE
Fixed formatting, modified link.

### DIFF
--- a/content/blog/blog-bite-does-the-non-exclusive-nature-of-a-consulting-agreement-affect-the-amount-of-damages-a-claimant-can-receive-for-early-termination/index.md
+++ b/content/blog/blog-bite-does-the-non-exclusive-nature-of-a-consulting-agreement-affect-the-amount-of-damages-a-claimant-can-receive-for-early-termination/index.md
@@ -3,10 +3,10 @@ title: "Blog Bite: Does the non-exclusive nature of a consulting agreement affec
 author: alina@clausehound.com
 tags: ["Termination","Employment Agreement","Consulting Agreement","Mondaq","Learn","Canada (ON)"]
 date: 2013-05-30 00:00:00
-description: "This article posted on our partner site Mondaq.com denotes the significance of an Ontario Superior Court decision in which the court held that the non-exclusive nature of a consulting agreement disen..."
+description: "This article posted on our partner site Mondaq denotes the significance of an Ontario Superior Court decision regarding the non-exclusive nature of a Consulting Agreement"
 ---
 
-[This article posted on our partner site Mondaq.com](https://www.mondaq.com/canada/employment-litigation-tribunals/242054/independent-contractors-and-their-rights-upon-termination) denotes the significance of an Ontario Superior Court decision in which the court held that the **non-exclusive nature of a consulting agreement** disentitled the claimant from receiving the full amount of the contract for his early termination. 
+[This article posted on our partner site Mondaq.com](https://www.mondaq.com/canada/employment-litigation-tribunals/242054/independent-contractors-and-their-rights-upon-termination) denotes the significance of an Ontario Superior Court decision in which the court held that the **non-exclusive nature of a Consulting Agreement** disentitled the claimant from receiving the full amount of the contract for his early termination. 
 
 The court awarded the claimant only the value of the time spent on the project prior to termination, but also expressed its disapproval of the defendant's mistreatment towards the claimant by awarding punitive damages and substantial costs as well.
 

--- a/content/blog/blog-bite-does-the-non-exclusive-nature-of-a-consulting-agreement-affect-the-amount-of-damages-a-claimant-can-receive-for-early-termination/index.md
+++ b/content/blog/blog-bite-does-the-non-exclusive-nature-of-a-consulting-agreement-affect-the-amount-of-damages-a-claimant-can-receive-for-early-termination/index.md
@@ -6,6 +6,8 @@ date: 2013-05-30 00:00:00
 description: "This article posted on our partner site Mondaq.com denotes the significance of an Ontario Superior Court decision in which the court held that the non-exclusive nature of a consulting agreement disen..."
 ---
 
-[This article posted on our partner site Mondaq.com](http://www.mondaq.com/404.asp?action=login&amp;404;http://www.mondaq.com:80/canada/x/242054/employment%20litigation%20tribunals/Independent%20Contractors%20And%20Their%20Rights%20Upon%20Termination=) denotes the significance of an Ontario Superior Court decision in which the court held that the non-exclusive nature of a consulting agreement disentitled the claimant from receiving the full amount of the contract for his early termination. The court awarded the claimant only the value of the time spent on the project prior to termination, but also expressed its disapproval of the defendant's mistreatment towards the claimant by awarding punitive damages and substantial costs as well.
+[This article posted on our partner site Mondaq.com](https://www.mondaq.com/canada/employment-litigation-tribunals/242054/independent-contractors-and-their-rights-upon-termination) denotes the significance of an Ontario Superior Court decision in which the court held that the **non-exclusive nature of a consulting agreement** disentitled the claimant from receiving the full amount of the contract for his early termination. 
+
+The court awarded the claimant only the value of the time spent on the project prior to termination, but also expressed its disapproval of the defendant's mistreatment towards the claimant by awarding punitive damages and substantial costs as well.
 
 This comes to you as a part of Clausehound's exciting new collaboration with Mondaq!


### PR DESCRIPTION
Separated whole paragraph into two.
Emphasized key words.


Modified Mondaq.com link
from (won't open):
http://www.mondaq.com/404.asp?action=login&amp;404;http://www.mondaq.com:80/canada/x/242054/employment%20litigation%20tribunals/Independent%20Contractors%20And%20Their%20Rights%20Upon%20Termination=

to:
https://www.mondaq.com/canada/employment-litigation-tribunals/242054/independent-contractors-and-their-rights-upon-termination