### PR TITLE
Fixed formatting & typo.

### DIFF
--- a/content/blog/what-is-the-difference-between-a-confidential-disclosure-agreement-cda-and-a-non-disclosure-agreement-nda/index.md
+++ b/content/blog/what-is-the-difference-between-a-confidential-disclosure-agreement-cda-and-a-non-disclosure-agreement-nda/index.md
@@ -1,12 +1,10 @@
 ---
 title: "What is the difference between a confidential disclosure agreement (CDA) and a non-disclosure agreement (NDA)?"
 author: frahman@cobaltcounsel.com
-tags: ["Confidentiality","NDA","Confidential Information","Confidentiality Agreement","frahman","Rajah"]
+tags: ["Confidentiality","NDA","Confidential Information","Confidentiality Agreement"]
 date: 2017-07-17 14:44:33
-description: "Links from this article:
-Scope of Confidential Information
+description: "Links from this article: This article highlights the key differences between a confidential disclosure agreement (CDA) and a non-disclosure agreement (NDA)."
 
-A number of agreements can contain the same clauses to protect certain information but still have different agreement names. For example, a..."
 ---
 
 

--- a/content/blog/what-is-the-difference-between-a-confidential-disclosure-agreement-cda-and-a-non-disclosure-agreement-nda/index.md
+++ b/content/blog/what-is-the-difference-between-a-confidential-disclosure-agreement-cda-and-a-non-disclosure-agreement-nda/index.md
@@ -9,38 +9,37 @@ Scope of Confidential Information
 A number of agreements can contain the same clauses to protect certain information but still have different agreement names. For example, a..."
 ---
 
-**Links from this article:**[Scope of Confidential Information](http://blog.clausehound.com/the-scope-of-your-confidential-information/)
 
-A number of agreements can contain the same clauses to protect certain information but still have different agreement names. For example, a software development agreement can also be known as a master services agreement or a technology services agreement. However, the purpose of the agreements remains the same.
-** **
-That being said, a confidential disclosure agreement and non-disclosure agreement may have different purposes. A confidential disclosure agreement is intended to disclose certain information, while a non-disclosure agreement is intended to protect certain information.
-** **
-The two terms are often used interchangeably despite nuances between them that generally relate to the nature of the relationship between the parties and the purpose of the agreement.
 
-Confidential Disclosure Agreement
-** **
-A confidential disclosure agreement (CDA) is generally entered into by parties looking to enter into a business relationship with each other and to disclose specific confidential information to each other. Parties entering into a referral or cross marketing agreement, joint venture, or merger/acquisition transaction might want to share information such as customer information or subscriber information, either as part of due diligence or as an active part of the arrangement. 
-** **
-This agreement would very likely includes a duty not to disclose such information to other third parties. The parties might also decide to use anonymization or redaction to avoid sharing too much information too readily. Of course, the parties will also need to adhere to applicable privacy laws as well as their own company terms of use and privacy policy to ensure that no over-sharing occurs.
+A number of agreements can contain the same clauses to protect certain information but still have different agreement names. For example, a *software development agreement* can also be known as a *master services agreement* or a *technology services agreement*. However, the purpose of the agreements remains the same.
 
-Non-Disclosure Agreement
-** **
-A non-disclosure agreement (NDA) is a more common confidentiality type agreement entered into for various reasons, like: 
-** **
-- 
-Entering into a business partnership;
+That being said, a **confidential disclosure agreement** and **non-disclosure agreement** may have *different purposes*. A confidential disclosure agreement is intended to disclose certain information, while a non-disclosure agreement is intended to protect certain information.
 
-- 
-Entering into an employment or contractor relationship; and
+The two (2) terms are often used interchangeably despite nuances between them that generally relate to the nature of the relationship between the parties and the purpose of the agreement.
 
-- 
-Inquiring about a potential business relationship.
+### Confidential Disclosure Agreement
 
-** **
-As you might gather, the first and last items are similar to the rationale for entering into a confidential information arrangement. Once again, context may be the differentiating factor. An NDA may be for a short term or may be replaced with a more comprehensive IP transfer and NDA at a later time in the business relationship. Conversely, a CDA might be for an ongoing period and might also contain mechanisms for information sharing, protection and audit.
-** **
+A confidential disclosure agreement (CDA) is generally entered into by parties looking to enter into a business relationship with each other and to disclose specific confidential information to each other. Parties entering into a *referral or cross-marketing agreement*, *joint venture*, or *merger/acquisition transaction* might want to share information such as customer information or subscriber information, either as part of due diligence or as an active part of the arrangement. 
+
+This agreement would very likely include a duty not to disclose such information to other third parties. The parties might also decide to use *anonymization* or *redaction* to avoid sharing too much information too readily. Of course, the parties will also need to adhere to applicable privacy laws as well as their own company terms of use and privacy policy to ensure that no over-sharing occurs.
+
+### Non-Disclosure Agreement
+
+A non-disclosure agreement (NDA) is a *more common confidentiality type agreement* entered into for various reasons, like: 
+
+- Entering into a business partnership;
+
+- Entering into an employment or contractor relationship; and
+
+- Inquiring about a potential business relationship.
+
+
+As you might gather, the first and last items are similar to the rationale for entering into a confidential information arrangement. Once again, *context* may be the differentiating factor. An NDA may be for a short term or may be replaced with a more comprehensive IP transfer and NDA at a later time in the business relationship. Conversely, a CDA might be for an ongoing period and might also contain mechanisms for information sharing, protection and audit.
+
 In both instruments, the purpose is to protect confidential information in relation to a certain individual or company. In order to ensure that parties will be willing to promise an obligation not to disclose confidential information, the agreement should generally include a [scope of confidential information](http://blog.clausehound.com/the-scope-of-your-confidential-information/) that is not too broad or not too narrow. 
 
  
 
-This article has illustrated that both agreements can provide the same effect and can therefore be confusing because, as noted above, the terms “confidential disclosure” and “nondisclosure” can be used interchangeably. This confusion is not limited to CDAs and NDAs—many legal agreements will have different titles, headings or terms with the same effect. For that reason, it is important to read the agreement carefully and, where possible, to consult with your legal counsel to make sure your obligations match your business decisions.
+This article has illustrated that both agreements can provide the same effect and can therefore be confusing because, as noted above, the terms “confidential disclosure” and “nondisclosure” can be used interchangeably. This confusion is not limited to CDAs and NDAs—many legal agreements will have different titles, headings or terms with the same effect. 
+
+For that reason, it is important to read the agreement carefully and, where possible, to consult with your legal counsel to make sure your obligations match your business decisions.


### PR DESCRIPTION
Subheadings set to ### (from ** **).
Separated a paragraph into 2.
Emphasized key words.

Removed the following:
- double asterisk (gray horizontal line in between paragraphs)
- first link in this article