### PR TITLE
Fixed formatting & typo.

### DIFF
--- a/content/blog/when-a-confidentiality-agreement-isnt-enough/index.md
+++ b/content/blog/when-a-confidentiality-agreement-isnt-enough/index.md
@@ -3,9 +3,8 @@ title: "When a Confidentiality Agreement Isn’t Enough…"
 author: info@clausehound.com
 tags: ["Confidentiality","NDA","Confidential Information","Long Form","Releases","Commercial Activities","Confidentiality Agreement","info@clausehound.com"]
 date: 2016-01-26 12:55:12
-description: "
+description: "This article describes how to protect specific confidential information, within or in addition to a Confidentiality Agreement."
 
-When determining how to protect specific confidential information, it is important to consider whether the terms of the confidential..."
 ---
 
 When determining how to protect specific confidential information, it is important to consider whether the terms of the confidentiality agreement offer at least the level of protection available under the common law.

--- a/content/blog/when-a-confidentiality-agreement-isnt-enough/index.md
+++ b/content/blog/when-a-confidentiality-agreement-isnt-enough/index.md
@@ -10,33 +10,36 @@ When determining how to protect specific confidential information, it is importa
 
 When determining how to protect specific confidential information, it is important to consider whether the terms of the confidentiality agreement offer at least the level of protection available under the common law.
 
-**When Will Confidential Information be Protected?**
+### When Will Confidential Information be Protected?
 
-Under the common law, confidential information will be protected if the person claiming the confidentiality of the information can show that they have the sole right to benefit from the use of that information, someone else has wrongfully used it, and damages have been suffered as a result. The courts will also apply a multi-pronged test to determine the confidential nature of the information. This will include for example, the question of whether the information is generally unknown to others, subject to some measure of secrecy or protection, is in some way unique or novel etc.
+Under the **common law**, confidential information will be protected if the person claiming the confidentiality of the information can show that they have the sole right to benefit from the use of that information, someone else has wrongfully used it, and damages have been suffered as a result. The courts will also apply a **multi-pronged test** to determine the confidential nature of the information. This will include for example, the question of whether the information is generally unknown to others, subject to some measure of secrecy or protection, is in some way unique or novel etc.
 
  
 
-**Definition of Confidential Information**
+### Definition of Confidential Information
 
-Under an NDA, the definition of confidential information can be expanded to provide contractual protection for information not considered confidential under the common law. **Drafters beware!** The way that confidential information is defined in the NDA could also turn out to be narrower than it would be under the common law.
+Under an NDA, the definition of confidential information can be expanded to provide contractual protection for information not considered confidential under the common law. 
 
-When drafting the NDA, lay out all the terms that you wish to include, clearly setting out what it is that you are seeking to protect, and compare it to the common law. In some circumstances it will turn out that the common law could have offered better protection for the confidential information. If so, consider including the broader definition of confidential information in the NDA.
+**Drafters beware!** 
+
+The way that confidential information is defined in the NDA could also turn out to be *narrower* than it would be under the common law.
+
+When drafting the NDA, lay out all the terms that you wish to include, clearly setting out what it is that you are seeking to protect, and compare it to the common law. In some circumstances it will turn out that the common law could have offered better protection for the confidential information. If so, consider including the *broader* definition of confidential information in the NDA.
 
 This could be especially important in the context of the sale of a business, where there are several bidders. If the confidential information is “defined” too narrowly, the successful bidder may run into the problem where the parties in question are utilizing the confidential/proprietorial information in a way that does not breach the agreement, but goes against the primary intentions of keeping the information out of the hands of the unsuccessful bidders. Ultimately, you may be permitting competitor organizations to use confidential information that was actually intended to remain confidential.
 
  
 
-**Application in Real-Life Cases**
+### Application in Real-Life Cases
 
-A prime example can be found in *Novawest Resources inc.*
-
-v. Anglo American Exploration (Canada) Ltd. et al. 2006 BCSC 769. The case involved a dispute between a successful bidder for a mining property, and an unsuccessful bidder. The NDA covered confidential information used to stake new claims in “the area of influence”, which was defined to include a 1 kilometer zone. The unsuccessful bidder used the information to stake claims beyond the 1 kilometer zone, claiming that this did not breach the terms of the non-competition clause contained in the NDA.
+A prime example can be found in *Novawest Resources Inc. v. Anglo American Exploration (Canada) Ltd. et al. 2006 BCSC 769*. The case involved a dispute between a successful bidder for a mining property, and an unsuccessful bidder. The NDA covered confidential information used to stake new claims in “the area of influence”, which was defined to include a 1 kilometer zone. The unsuccessful bidder used the information to stake claims beyond the 1 kilometer zone, claiming that this did not breach the terms of the non-competition clause contained in the NDA.
 
 The court agreed with this interpretation of the agreement, and concluded that the agreement permitted the unsuccessful bidder to stake anywhere outside the “area of influence”. Under the common law, the information was clearly confidential, and the unsuccessful bidder(s) would have been prevented from using the information to stake claims anywhere. Since the parties had voluntarily bound themselves to the terms of this agreement, they were held to the terms of their bargain. The court declined to read in the ‘extra’ restrictions of the common law.
 
  
 
-**Takeaways:**
-- the definition of ‘confidential information’ should be drafted broadly to capture all of the information which is to be protected
-- non-competition and non-use provisions should be drafted to include all types of competition and uses which are to be restricted
-- comparing the definitions in the NDA with the protection offered under the common law can reveal any gaps in the NDA
+### Takeaways:
+
+- the definition of **‘confidential information’** should be drafted broadly to capture all of the information which is to be protected
+- **non-competition and non-use provisions** should be drafted to include *all types of competition and uses* which are to be restricted
+- comparing the definitions in the **NDA** with the protection offered under the **common law** can reveal any *gaps* in the NDA


### PR DESCRIPTION
Subheadings set to ### (from ** **).
"Drafters beware" set to bold & placed on its own line under the subheading "Definition of Confidential Information".

Emphasized key words.