### PR TITLE
Fixed formatting, modified link.

### DIFF
--- a/content/blog/protection-of-confidential-information/index.md
+++ b/content/blog/protection-of-confidential-information/index.md
@@ -6,23 +6,21 @@ date: 2016-01-01 17:01:51
 description: "Links from this article:my post on data securityI am often asked to either draft or review non-disclosure agreements. Withi..."
 ---
 
-**Links from this article:**
-[my post on data security](http://multiplicity.media/2014/11/10/data-security-essential-company-credibility/)
 
-I am often asked to either draft or review non-disclosure agreements. Within a standard agreement I will typically come across or include a clause on the standard of care required for safeguarding confidential information.
+I am often asked to either draft or review non-disclosure agreements. Within a standard agreement I will typically come across or include a clause on the standard of care required for *safeguarding* confidential information.
 
 The clause might be worded as follows:
 
-Confidential information is handled, at minimum, in the same way that the recipient would handle their own confidential information [or “in no event less than reasonable degree of care”, or in “strict confidence”, or at the “highest standard of care];  neither party shall be liable for the inadvertent or accidental disclosure of confidential information if such disclosure occurs despite the exercise of such care.**** ****
+*Confidential information is handled, at minimum, in the same way that the recipient would handle their own confidential information [or “in no event less than reasonable degree of care”, or in “strict confidence”, or at the “highest standard of care];  neither party shall be liable for the inadvertent or accidental disclosure of confidential information if such disclosure occurs despite the exercise of such care.*
 
 The language noted above is not appropriate in all circumstances, but can be modified to suit the custom needs of the disclosure and recipient.
 
-I was recently asked about the steps required in safeguarding information.  For the safeguarding of information stored electronically, please refer to [my post on data security](http://multiplicity.media/2014/11/10/data-security-essential-company-credibility/).
+I was recently asked about the steps required in safeguarding information.  For the safeguarding of information stored **electronically**, please refer to [my post on data security](https://blog.clausehound.com/data-security-is-essential-for-company-credibility/).
 
-With respect to the safeguarding of information stored in physical files, I spent some time considering the recommendations of the Privacy Commission in response to complaints made against businesses on their handling of confidential information, to come up with the following  list of recommendations:
+With respect to the safeguarding of information stored in physical files, I spent some time considering the recommendations of the *Privacy Commission* in response to complaints made against businesses on their handling of confidential information, to come up with the following  list of recommendations:
 
 - Ensure separation of confidential information storage/processing and open areas (such as your office reception area);
-- Ensure that access to confidential information storage and processing areas is key-controlled;
+- Ensure that access to confidential information storage and processing areas is *key-controlled*;
 - Ensure locked and guarded access to confidential information stored offsite: i.e. ensure information in storage is held off-site in a secure fenced facility, where entry is controlled by a security guard;
 - Ensure that a system exists for the monitoring and tracking of access to confidential information;
 - Ensure pre-screening and training of employees who have access to confidential information (with respect to training, employees should be oriented on their obligations to maintain the confidentiality and security of confidential information); and

--- a/content/blog/protection-of-confidential-information/index.md
+++ b/content/blog/protection-of-confidential-information/index.md
@@ -3,7 +3,10 @@ title: "Protection of Confidential Information"
 author: rajah@cobaltcounsel.com
 tags: ["NDA","Handling of Confidential Information","Safeguarding Requirements","Long Form","Technology","Commercial Activities","Rajah"]
 date: 2016-01-01 17:01:51
-description: "Links from this article:my post on data securityI am often asked to either draft or review non-disclosure agreements. Withi..."
+description: "This article discusses protection of confidential information."
+
+
+
 ---
 
 


### PR DESCRIPTION
Removed first link from this article.
Emphasized key words.

Modified from (won't open):
[my post on data security](http://multiplicity.media/2014/11/10/data-security-essential-company-credibility/)
to best guess:
(https://blog.clausehound.com/data-security-is-essential-for-company-credibility/)