### PR TITLE
Fixed formatting & removed/modified some links.

### DIFF
--- a/content/blog/how-do-i-make-a-terms-and-conditions-user-friendly-while-also-protecting-my-legal-rights/index.md
+++ b/content/blog/how-do-i-make-a-terms-and-conditions-user-friendly-while-also-protecting-my-legal-rights/index.md
@@ -16,26 +16,35 @@ Terms of Use. Terms of Servic..."
 
  
 
-**Links from this article:**[Source ](https://about.500px.com/terms/)[published an article on this very topic](http://www.theatlantic.com/technology/archive/2012/04/behold-a-terms-of-service-agreement-that-is-actually-user-friendly/255803/)[Source](https://termsfeed.com/blog/browsewrap-clickwrap/)[Nguyen v. Barnes & Noble, Inc.](http://blog.clausehound.com/doubt-on-acceptance-of-terms-of-use/)
 
-Terms of Use. Terms of Service. Terms and Conditions. You’ve probably never paid much attention to them, despite them being on every website you visit online. The problem with Terms of Use (TOU) is that they are difficult to read and understand, and if you really want to use the site, you have to agree to them anyway. 
+*Terms of Use*. *Terms of Service*. *Terms and Conditions*. You’ve probably never paid much attention to them, despite them being on every website you visit online. The problem with **Terms of Use (TOU)** is that they are difficult to read and understand, and if you really want to use the site, you have to agree to them anyway. 
 
 But if you are the owner of the website, having the user bound by those terms and conditions is very important. How can you increase the odds that the user will be bound? One way is to try to draft them in simpler language. At the same time, it is important to make sure that legal rights are not lost in your effort to offer users a more readable TOU.
 
-Simplify the languageThe Atlantic [published an article on this very topic](http://www.theatlantic.com/technology/archive/2012/04/behold-a-terms-of-service-agreement-that-is-actually-user-friendly/255803/) and used website 500px as a prime example. The website offers its legalese in a column on the left and a simplification in a column on the right, with the disclaimer that the latter column “is not legally binding.” This arrangement, while superficially elegant, does nothing to address the problem that exists regardless of form—the user lacks comprehension, be it of the meaning of the rigid legalese or the legal implications that are lost when the terms are oversimplified. So overly simple language is not a solution by itself.
+### Simplify the language
+
+The Atlantic [published an article on this very topic](http://www.theatlantic.com/technology/archive/2012/04/behold-a-terms-of-service-agreement-that-is-actually-user-friendly/255803/) and used website 500px as a prime example. The website offers its *legalese* in a column on the left and a *simplification* in a column on the right, with the disclaimer that the latter column “is not legally binding.” This arrangement, while superficially elegant, does nothing to address the problem that exists regardless of form—the user lacks comprehension, be it of the meaning of the rigid legalese or the legal implications that are lost when the terms are oversimplified. So overly simple language is not a solution by itself.
 
 Legalese is notoriously convoluted and long-winded, with sentences that trail off out of sight and out of mind. The syntax and grammar of the TOU should be overhauled to be clear and more concise, using the grammar of modern English.
 
-Visual clues to meaningA visual overhaul of TOU to include clear headers and less densely-packed text can make them more appealing to read. The user experience is all about quickness and a good interface, and so far most TOU’s are only good at being overwhelming and ugly. Clickwrap or Browsewrap?At the end of the day—and at the bottom of the TOU—user engagement and acknowledgement is paramount. 
+### Visual clues to meaning
 
-Composing a good TOU is just half the battle, because a user still has to opt-in, be it through an active action or a passive one. A distinction can be made between “clickwrap” TOU that engage users through a positive action (requiring they “Accept” the terms or not) and “browsewrap” TOU, which exist as a hyperlink on the page a user is visiting and is not required to be viewed.
+A visual overhaul of TOU to include clear headers and less densely-packed text can make them more appealing to read. The user experience is all about quickness and a good interface, and so far most TOU’s are only good at being overwhelming and ugly.
+
+### Clickwrap or Browsewrap?
+
+At the end of the day—and at the bottom of the TOU—user engagement and acknowledgement is paramount. 
+
+Composing a good TOU is just half the battle, because a user still has to *opt-in*, be it through an active action or a passive one. A distinction can be made between “clickwrap” TOU that engage users through a positive action (requiring they “Accept” the terms or not) and “browsewrap” TOU, which exist as a hyperlink on the page a user is visiting and is not required to be viewed.
 
  
 
 Whether or not either of these avenues is legally binding can depend on what country you are in.
 
-In the U.S. Ninth Circuit case [Nguyen v. Barnes & Noble, Inc. (2014)](http://blog.clausehound.com/doubt-on-acceptance-of-terms-of-use/), the user sued the bookstore for deceptive online business practices. The bookstore argued that the user could not sue because of an arbitration clause in the site’s terms. The court decided that  “the user was successful in arguing that they weren’t subject to the terms of use of a website that had a browsewrap agreement.”However, in the Canadian case of [Century 21 Canada Limited Partnership v. Rogers Communications Inc. (2011) (BCSC)](http://www.canlii.org/en/bc/bcsc/doc/2011/2011bcsc1196/2011bcsc1196.html?searchUrlHash=AAAAAQAOImJyb3dzZSB3cmFwIiAAAAAAAQ&amp;resultIndex=1), browsewrap TOU were found to be enforceable against users. While it appears that non-prompting TaC may be legally binding in Canada, the very recent decision in Nguyen v. Barnes & Noble, Inc. and the otherwise complete lack of case law on this specific matter, especially in Canada, should suggest that it’s better to be safe than sorry—so be sure to clickwrap your shiny, new, and user-friendly TOU.
+In the *U.S. Ninth Circuit case* [Nguyen v. Barnes & Noble, Inc. (2014)](http://blog.clausehound.com/doubt-on-acceptance-of-terms-of-use/), the user sued the bookstore for deceptive online business practices. The bookstore argued that the user could not sue because of an arbitration clause in the site’s terms. The court decided that  “the user was successful in arguing that they weren’t subject to the terms of use of a website that had a browsewrap agreement.”
+
+However, in the *Canadian case* of [Century 21 Canada Limited Partnership v. Rogers Communications Inc. (2011) (BCSC)](http://www.canlii.org/en/bc/bcsc/doc/2011/2011bcsc1196/2011bcsc1196.html?searchUrlHash=AAAAAQAOImJyb3dzZSB3cmFwIiAAAAAAAQ&amp;resultIndex=1), browsewrap TOU were found to be enforceable against users. While it appears that non-prompting TaC may be legally binding in Canada, the very recent decision in Nguyen v. Barnes & Noble, Inc. and the otherwise complete lack of case law on this specific matter, especially in Canada, should suggest that it’s better to be safe than sorry—so be sure to **clickwrap** your shiny, new, and user-friendly TOU.
 
 In the end, using simpler words, clear grammar, good organization and a clickwrap TOU can go a long way to engaging the user and increasing the chances that they will be bound by the terms and conditions presented.
 
-To see a standard set of terms and conditions, visit our [Small Business Law Library](https://clausehound.com/legal-contract/14918/#!/document=)!
+To see a standard set of terms and conditions, visit our [Small Business Law Library](https://www.clausehound.com/documents/)!

--- a/content/blog/how-do-i-make-a-terms-and-conditions-user-friendly-while-also-protecting-my-legal-rights/index.md
+++ b/content/blog/how-do-i-make-a-terms-and-conditions-user-friendly-while-also-protecting-my-legal-rights/index.md
@@ -3,15 +3,9 @@ title: "How do I make a “Terms and Conditions” user friendly while also prot
 author: frahman@cobaltcounsel.com
 tags: ["Terms of Use","Website Terms of Use","Commercial Activities","Venturelaw","frahman"]
 date: 2016-10-09 13:16:30
-description: "Links from this article:
-Source 
-published an article on this very topic
-Source
-Nguyen v. Barnes & Noble, Inc.
+description: "This article provides a guideline on how to create user friendly "Terms and Conditions", while still protecting legal rights."
 
 
-
-Terms of Use. Terms of Servic..."
 ---
 
  


### PR DESCRIPTION
Separated whole paragraph into smaller ones.
Subheading placed on its own line.
Emphasized key words.

Modified:
Small Business Law Library site-user agreement
changed from (won't open):
https://clausehound.com/legal-contract/14918/#!/document=
to:
https://www.clausehound.com/documents/